### PR TITLE
Rweber/big fsm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-checked-fsm",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A typescript library for defining state machine types with compile-time transition validation. Types are fun.",
   "main": "index.js",
   "typings": "types/index.d.ts",

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -40,7 +40,6 @@ type IllegalTransitionError = 'No transition exists from the current state to th
 type ActionAlreadyDeclared = 'An action with this label has already been declared.';
 type HandlerNotAState = 'The returned value is not a state';
 type NoHandlerForState = 'Missing handler for some non-terminal state';
-type ActionAlreadyHandled = 'Action already handled for this state';
 
 type IndexType = string | number | symbol;
 
@@ -48,13 +47,7 @@ type IndexType = string | number | symbol;
 type AssertNewState<S extends StateType, States> = S extends States ? ErrorBrand<StateAlreadyDeclaredError> : S;
 type AssertNewTransition<S extends StateType, N extends StateType, Transitions> = S extends keyof Transitions ? N extends Transitions[S] ? ErrorBrand<TransitionAlreadyDeclaredError> : N : N;
 type AssertActionNotDefined<AN extends ActionNameType, ActionNames extends IndexType> = AN extends ActionNames ? ErrorBrand<ActionAlreadyDeclared> : AN;
-type AssertActionNotAlreadyHandled<S extends StateType, AN extends ActionNameType, ActionMap> = 
-  S extends keyof ActionMap
-  ? AN extends ActionMap[S] 
-  ? ErrorBrand<ActionAlreadyHandled>
-  : AN
-  : AN;
-type AssertAllNonTerminalStatesHandled<StateMap, Transitions, HandledStates> = 
+type AssertAllNonTerminalStatesHandled<Transitions, HandledStates> = 
   keyof Transitions extends HandledStates
   ? HandledStates extends keyof Transitions 
   ? void
@@ -224,7 +217,7 @@ type DoneBuilder = <StateMap, ActionMap, Transitions, HandledStates>(definition:
 
 // Check that the only unhandled states in the handler map are final states (i.e, they have no transitions out of them)
 type DoneFunc<StateMap, ActionMap, Transitions, HandledStates> = 
-  (_: AssertAllNonTerminalStatesHandled<StateMap, Transitions, HandledStates>) => StateMachine<StateMap, ActionMap>;
+  (_: AssertAllNonTerminalStatesHandled<Transitions, HandledStates>) => StateMachine<StateMap, ActionMap>;
 
 /**
  * A state machine
@@ -318,7 +311,7 @@ const actionHandler = <StateMap, Transitions, ActionMap, HandledStates>(definiti
 
 const done: DoneBuilder = <StateMap, ActionMap, Transitions, HandledStates>(definition: StateMachineDefinition<StateMap, ActionMap>) => {
   const doneFunc: DoneFunc<StateMap, ActionMap, Transitions, HandledStates> = (
-    _: AssertAllNonTerminalStatesHandled<StateMap, Transitions, HandledStates>
+    _: AssertAllNonTerminalStatesHandled<Transitions, HandledStates>
   ): StateMachine<StateMap, ActionMap> => {
     const nextStateFunction = (curState: StateMap[keyof StateMap], action: ActionMap[keyof ActionMap]): StateMap[keyof StateMap] => {
       const curStateAsState = curState as unknown as State<string, {}>;

--- a/test/StateMachine.ts
+++ b/test/StateMachine.ts
@@ -345,7 +345,8 @@ describe('compile-time checking', () => {
             });
     });
 
-    it('should fail when declaring handler for same state+action', () => {
+    // TODO: Find a way to fix this without causing infinite type complaints
+    it('should allow declaring handler for same state+action', () => {
         type Payload1 = { foo: '7' };
         type Payload2 = { bar: '8' };
 
@@ -364,7 +365,6 @@ describe('compile-time checking', () => {
                     foo: '7'
                 };
             })
-            // @ts-expect-error
             .actionHandler('a', 'a1', (_c, _a) => {
                 return Math.random () > 0.5 ? {
                     stateName: 'b',
@@ -536,4 +536,157 @@ describe('compile-time checking', () => {
             })
             .done();
     });
+
+    it('Should allow large state machines', () => {
+        const NO_DOC = {
+            stateName: 'no-doc' as const
+        };
+
+        const NEW_DOC_STATE = {
+            stateName: 'unnamed-doc' as const
+        };
+
+        const NAMED_DOC = {
+            stateName: 'named-doc' as const
+        };
+
+        const FAILED_LOAD_DOC_STATE = {
+            stateName: 'unrecoverable-error' as const
+        };
+
+        stateMachine()
+            .state('no-doc')
+            .state('unrecoverable-error')
+            .state('unnamed-doc')
+            .state('named-doc')
+            .transition('no-doc', 'unnamed-doc') // new
+            .transition('no-doc', 'named-doc') // open
+            .transition('no-doc', 'unrecoverable-error') // error page
+            .transition('unrecoverable-error', 'no-doc') // close error
+            .transition('unnamed-doc', 'unnamed-doc') // new
+            .transition('unnamed-doc', 'named-doc') // save as or open
+            .transition('unnamed-doc', 'no-doc') // close
+            .transition('unnamed-doc', 'unrecoverable-error') // error page
+            .transition('named-doc', 'no-doc') // close
+            .transition('named-doc', 'named-doc') // save as
+            .transition('named-doc', 'unnamed-doc') // new
+            .transition('named-doc', 'unrecoverable-error') // error page
+            .action('new-flow') // Fired on new
+            .action('named-flow-success') // Fired on save, save as, load
+            .action('failure') // Fired on failure to load a flow
+            .action('access-denied') // Also fired on failure to load a flow
+            .action('close-flow')
+            .action('update-doc-version')
+            .action('user-create-connection')
+            .action('new-flow1') // Fired on new
+            .action('named-flow-success1') // Fired on save, save as, load
+            .action('failure1') // Fired on failure to load a flow
+            .action('access-denied1') // Also fired on failure to load a flow
+            .action('close-flow1')
+            .action('update-doc-version1')
+            .action('user-create-connection1')
+            .actionHandler('no-doc', 'new-flow', (_c, _a) => {
+                return NEW_DOC_STATE;
+            })
+            .actionHandler('no-doc', 'failure', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('no-doc', 'access-denied', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('no-doc', 'named-flow-success', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('unnamed-doc', 'close-flow', (_c, _a) => {
+                return NO_DOC;
+            })
+            .actionHandler('unnamed-doc', 'new-flow', (_c, _a) => {
+                return NEW_DOC_STATE;
+            })
+            .actionHandler('unnamed-doc', 'named-flow-success', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('unnamed-doc', 'update-doc-version', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('unnamed-doc', 'failure', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('unnamed-doc', 'access-denied', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('named-doc', 'close-flow', (_c, _a) => {
+                return NO_DOC;
+            })
+            .actionHandler('named-doc', 'new-flow', (_c, _a) => {
+                return NEW_DOC_STATE;
+            })
+            .actionHandler('named-doc', 'named-flow-success', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('named-doc', 'update-doc-version', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('named-doc', 'failure', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('named-doc', 'access-denied', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('unrecoverable-error', 'close-flow', (_c, _a) => {
+                return NO_DOC;
+            })
+            .actionHandler('no-doc', 'new-flow', (_c, _a) => {
+                return NEW_DOC_STATE;
+            })
+            .actionHandler('no-doc', 'failure', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('no-doc', 'access-denied', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('no-doc', 'named-flow-success', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('unnamed-doc', 'close-flow', (_c, _a) => {
+                return NO_DOC;
+            })
+            .actionHandler('unnamed-doc', 'new-flow', (_c, _a) => {
+                return NEW_DOC_STATE;
+            })
+            .actionHandler('unnamed-doc', 'named-flow-success', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('unnamed-doc', 'update-doc-version', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('unnamed-doc', 'failure', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('unnamed-doc', 'access-denied', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('named-doc', 'close-flow', (_c, _a) => {
+                return NO_DOC;
+            })
+            .actionHandler('named-doc', 'new-flow', (_c, _a) => {
+                return NEW_DOC_STATE;
+            })
+            .actionHandler('named-doc', 'named-flow-success', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('named-doc', 'update-doc-version', (_c, _a) => {
+                return NAMED_DOC;
+            })
+            .actionHandler('named-doc', 'failure', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('named-doc', 'access-denied', (_c, _a) => {
+                return FAILED_LOAD_DOC_STATE;
+            })
+            .actionHandler('unrecoverable-error', 'close-flow', (_c, _a) => {
+                return NO_DOC;
+            })
+            .done();
+    })
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
     new CopyPkgJsonPlugin({
         new: {
           "name": "ts-checked-fsm",
-          "version": "1.0.5",
+          "version": "1.0.6",
           "description": "A typescript library for defining state machine types with compile-time transition validation. Types are fun.",
           "main": "index.js",
           "typings": "types/index.d.ts",


### PR DESCRIPTION
Allow for larger FiniteStateMachines with Typescript 4.1.5 by removing a duplicate handler check. If you do this, last one wins.