### PR TITLE
Fix423

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,15 @@
+# v1.1.0
+* Fixed "Recusrive type is too deep and possibly infinite errors." This error existed in Typescript 4.1.5 and earlier, but was harder to trigger, requiring large complex state machines. Typescript 4.2.3 caused this to happen for smaller state machines. The root problem is that type multimaps expressed using index types required nested conditionals. To fix this, we now use use unions of key/value pair tuples to express the type map primitive. This allows us to build the map without conditionals and merely needs conditionals for lookups (which aren't in the "critical path" of the type builder).
+* We now use mapped type literals (e.g. ```ErrorBrand<`${S} is not a state`>```) in our errors to give you very direct and clear error messages as to the exact type causing the error.
+* The typemap changes caused a type widening issue in inferring the state return value of action handlers. You now need to put `as const` after all your returned states. See `Readme.md` example. This may be a breaking change if you weren't doing this before, but will be compatible if we're able to remove this restriction in the future.
+
+# v1.0.6
+* Fixed Webpack issues that made v1.0.0 unusable.
+* Added tests, including compile-time tests that assert you indeed get compilation failures for illegal uses. `// @ts-expect-error` is very handy for testing complex types.
+
+# v1.0.0
+* Major rewrite of ts-checked-fsm. Removed `validateState` callback and `ValidatedState` vs `UnvalidatedState` type, which was a cool proof of concept but a really annoying API.
+* Introduced actions and action handlers into builder pattern. The final product of the `stateMachine` builder is now simply a `nextState` function. Call it with the current state and an action and it returns the state resulting from the appropriate action handler.
+
+# v0.3.0
+* Initial public release of `ts-checked-fsm`.

--- a/Readme.md
+++ b/Readme.md
@@ -59,25 +59,25 @@ The library uses Error branding and intentionally causes failed type assignments
           return {
               stateName: 'get-money',
               moneyInserted: a.money,
-          };
+          } as const;
       })
       .actionHandler('get-money', 'insert-money', (c, a) => {
           return {
               stateName: 'get-money',
               moneyInserted: c.moneyInserted + a.money
-          };
+          } as const;
       })
       .actionHandler('get-money', 'vend-soda', (c, _a) => {
           return c.moneyInserted >= 50 ? {
               stateName: 'vend',
               changeRemaining: c.moneyInserted - 50
-          } : c;
+          } as const : c as const;
       })
       .actionHandler('vend', 'clock-tick', (c, _a) => {
           return {
               stateName: 'dispense-change',
               changeRemaining: c.changeRemaining
-          };
+          } as const;
       })
       .actionHandler('dispense-change', 'clock-tick', (c, _a) => {
           const coinVal = c.changeRemaining >= 25
@@ -91,9 +91,9 @@ The library uses Error branding and intentionally causes failed type assignments
           return c.changeRemaining - coinVal > 0 ? {
               stateName: 'dispense-change',
               changeRemaining: c.changeRemaining - coinVal
-          } : {
+          } as const : {
               stateName: 'idle'
-          };
+          } as const;
       })
       .done();
 
@@ -123,6 +123,9 @@ The library uses Error branding and intentionally causes failed type assignments
 * You don't have to declare handlers for final states (i.e. those that have no transitions out of them). If fact, it's illegal to do so since they have no valid transitions out of them!
 * As shown in the example, states and actions can have a payload.
 * For handlers that can return multiple state types depending on some condition, every state must be a legal transition.
+
+## How it works
+This library uses clever constructions using Typescript's type system. More details in this blog [post](https://engineering.tableau.com/really-advanced-typescript-types-c590eee59a12).
 
 # Get started
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-checked-fsm",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "A typescript library for defining state machine types with compile-time transition validation. Types are fun.",
   "main": "index.js",
   "typings": "types/index.d.ts",

--- a/test/StateMachine.ts
+++ b/test/StateMachine.ts
@@ -9,7 +9,7 @@ describe('state machine', () => {
             .action('a1')
             .actionHandler('a', 'a1', (_c, _) => {
                 return {
-                    stateName: 'b',
+                    stateName: 'b' as const,
                 };
             })
             .done();
@@ -29,7 +29,7 @@ describe('state machine', () => {
             .action('a2')
             .actionHandler('a', 'a1', (_c, _) => {
                 return {
-                    stateName: 'b',
+                    stateName: 'b' as const,
                 };
             })
             .done();
@@ -49,7 +49,7 @@ describe('state machine', () => {
             .action('a2')
             .actionHandler('a', 'a1', (_c, _) => {
                 return {
-                    stateName: 'b',
+                    stateName: 'b' as const,
                     count: 7,
                 };
             })
@@ -88,25 +88,25 @@ describe('state machine', () => {
             .action<'clock-tick'>('clock-tick')
             .actionHandler('idle', 'insert-money', (_c, a) => {
                 return {
-                    stateName: 'get-money',
+                    stateName: 'get-money' as const,
                     moneyInserted: a.money,
                 };
             })
             .actionHandler('get-money', 'insert-money', (c, a) => {
                 return {
-                    stateName: 'get-money',
+                    stateName: 'get-money' as const,
                     moneyInserted: c.moneyInserted + a.money
                 };
             })
             .actionHandler('get-money', 'vend-soda', (c, _a) => {
                 return c.moneyInserted >= 50 ? {
-                    stateName: 'vend',
+                    stateName: 'vend' as const,
                     changeRemaining: c.moneyInserted - 50
                 } : c;
             })
             .actionHandler('vend', 'clock-tick', (c, _a) => {
                 return {
-                    stateName: 'dispense-change',
+                    stateName: 'dispense-change' as const,
                     changeRemaining: c.changeRemaining
                 };
             })
@@ -120,10 +120,10 @@ describe('state machine', () => {
                     : 1;
 
                 return c.changeRemaining - coinVal > 0 ? {
-                    stateName: 'dispense-change',
+                    stateName: 'dispense-change' as const,
                     changeRemaining: c.changeRemaining - coinVal
                 } : {
-                    stateName: 'idle'
+                    stateName: 'idle' as const
                 };
             })
             .done();
@@ -189,7 +189,7 @@ describe('compile-time checking', () => {
             .state<'a'>('a')
             .state<'b'>('b')
             // @ts-expect-error
-            .transition('a', 'c');
+            .transition('a', 'c')
     });
 
     it('should fail when declaring same action more than once', () => {
@@ -267,7 +267,7 @@ describe('compile-time checking', () => {
             // @ts-expect-error
             .actionHandler('a', 'a1', () => {
                 return {
-                    stateName: 'c'
+                    stateName: 'c' as const
                 };
             });
     });
@@ -295,9 +295,9 @@ describe('compile-time checking', () => {
             .action('a1')
             .actionHandler('a', 'a1', (_c, _a) => {
                 return Math.random () > 0.5 ? {
-                    stateName: 'b'
+                    stateName: 'b' as const
                 } : {
-                    stateName: 'a'
+                    stateName: 'a' as const
                 };
             });
     });
@@ -316,10 +316,10 @@ describe('compile-time checking', () => {
                 return Math.random () > 0.5 ? {
                     stateName: 'b',
                     bar: '8'
-                } : {
+                } as const : {
                     stateName: 'a',
                     foo: '7'
-                };
+                } as const;
             });
     });
 
@@ -360,19 +360,19 @@ describe('compile-time checking', () => {
                 return Math.random () > 0.5 ? {
                     stateName: 'b',
                     bar: '8'
-                } : {
+                } as const : {
                     stateName: 'a',
                     foo: '7'
-                };
+                } as const;
             })
             .actionHandler('a', 'a1', (_c, _a) => {
                 return Math.random () > 0.5 ? {
                     stateName: 'b',
                     bar: '8'
-                } : {
+                } as const : {
                     stateName: 'a',
                     foo: '7'
-                };
+                } as const;
             });
     });
 
@@ -391,16 +391,16 @@ describe('compile-time checking', () => {
                 return Math.random () > 0.5 ? {
                     stateName: 'b',
                     bar: '8'
-                } : {
+                } as const : {
                     stateName: 'a',
                     foo: '7'
-                };
+                } as const;
             })
             .actionHandler('b', 'a1', (_c, _a) => {
                 return {
                     stateName: 'b',
                     bar: '8'
-                };
+                } as const;
             });
     });
 
@@ -418,16 +418,16 @@ describe('compile-time checking', () => {
             .action<'a1', ActionPayload>('a1')
             .actionHandler('a', 'a1', (_c, a) => {
                 return Math.random () > 0.5 ? {
-                    stateName: 'b',
+                    stateName: 'b' as const,
                     bar: a.val
                 } : {
-                    stateName: 'a',
+                    stateName: 'a' as const,
                     foo: a.val
                 };
             })
             .actionHandler('b', 'a1', (_c, a) => {
                 return {
-                    stateName: 'b',
+                    stateName: 'b' as const,
                     bar: a.val + 7
                 };
             });
@@ -448,10 +448,10 @@ describe('compile-time checking', () => {
                 return Math.random () > 0.5 ? {
                     stateName: 'b',
                     bar: '8'
-                } : {
+                } as const : {
                     stateName: 'a',
                     foo: '7'
-                };
+                } as const;
             })
             // @ts-expect-error
             .done();
@@ -472,7 +472,7 @@ describe('compile-time checking', () => {
                 return {
                     stateName: 'b',
                     bar: '8',
-                }
+                } as const;
             })
             // @ts-expect-error
             .done();
@@ -493,13 +493,13 @@ describe('compile-time checking', () => {
                 return {
                     stateName: 'b',
                     bar: '8',
-                }
+                } as const;
             })
             .actionHandler('b', 'a1', (_c, _a) => {
                 return {
                     stateName: 'c',
                     bar: '8',
-                }
+                } as const;
             })
             .done();
     });
@@ -520,19 +520,19 @@ describe('compile-time checking', () => {
                 return {
                     stateName: 'b',
                     bar: '8',
-                }
+                } as const;
             })
             .actionHandler('b', 'a1', (_c, _a) => {
                 return {
                     stateName: 'c',
                     bar: '8',
-                }
+                } as const
             })
             .actionHandler('c', 'a1', (_c, _a) => {
                 return {
                     stateName: 'a',
                     foo: '7',
-                }
+                } as const;
             })
             .done();
     });

--- a/test/StateMachine.ts
+++ b/test/StateMachine.ts
@@ -9,8 +9,8 @@ describe('state machine', () => {
             .action('a1')
             .actionHandler('a', 'a1', (_c, _) => {
                 return {
-                    stateName: 'b' as const,
-                };
+                    stateName: 'b',
+                } as const;
             })
             .done();
 
@@ -418,18 +418,18 @@ describe('compile-time checking', () => {
             .action<'a1', ActionPayload>('a1')
             .actionHandler('a', 'a1', (_c, a) => {
                 return Math.random () > 0.5 ? {
-                    stateName: 'b' as const,
+                    stateName: 'b',
                     bar: a.val
-                } : {
-                    stateName: 'a' as const,
+                } as const : {
+                    stateName: 'a',
                     foo: a.val
-                };
+                } as const;
             })
             .actionHandler('b', 'a1', (_c, a) => {
                 return {
-                    stateName: 'b' as const,
+                    stateName: 'b',
                     bar: a.val + 7
-                };
+                } as const;
             });
     });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
     new CopyPkgJsonPlugin({
         new: {
           "name": "ts-checked-fsm",
-          "version": "1.0.6",
+          "version": "1.1.0",
           "description": "A typescript library for defining state machine types with compile-time transition validation. Types are fun.",
           "main": "index.js",
           "typings": "types/index.d.ts",


### PR DESCRIPTION
These changes fix "type is deeply nested and possibly infinite" errors. This happens in Typescript 4.1.5 and earlier with fairly large and complex state machines, but blows up much sooner with newer releases.

The main thrust of this change is instead of using an index type for type-multimaps, we use a union of key value tuples in constructing the maps. The former requires conditionals in the critical path, while the latter does not. Unfortunately, a side effect of this change is that you now need `as const` in your handlers to prevent type widening.