### PR TITLE
Fix action handler typing

### DIFF
--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -268,7 +268,7 @@ const action = <StateMap, Transitions, ActionMap>(): ActionFunc<StateMap, Transi
 }
 
 const actionHandler = <StateMap, Transitions, ActionMap, HandledStates>(definition: StateMachineDefinition<StateMap, ActionMap>): ActionHandlerFunc<StateMap, Transitions, ActionMap, HandledStates> => {
-  const actionHandlerFunc: ActionHandlerFunc<StateMap, Transitions, ActionMap, HandledStates> = <S extends StateType, AN extends ActionNameType, NS extends MapValues<StateMap>>(
+  return <S extends StateType, AN extends ActionNameType, NS extends MapValues<StateMap>>(
     state: S,
     action: AN,
     handler: ActionHandlerCallback<StateMap, Transitions, S, AN, NS, ActionMap>
@@ -294,8 +294,6 @@ const actionHandler = <StateMap, Transitions, ActionMap, HandledStates>(definiti
       done: doneFunc
     };
   };
-
-  return actionHandlerFunc;
 };
 
 const done: DoneBuilder = <StateMap, ActionMap, Transitions, HandledStates>(definition: StateMachineDefinition<StateMap, ActionMap>) => {

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -40,6 +40,7 @@ type AssertStateInMap<StateMap, S extends StateType> = S extends MapKeys<StateMa
 type AssertNewState<S extends StateType, States> = S extends MapKeys<States> ? ErrorBrand<`'${S}' has already been declared`> : S;
 type AssertNewTransition<S extends StateType, N extends StateType, Transitions> = N extends MapLookup<Transitions, S> ? ErrorBrand<`There already exists a transition from '${S}' to '${N}'`> : N;
 type AssertActionNotDefined<AN extends ActionNameType, ActionNames extends IndexType> = AN extends ActionNames ? ErrorBrand<`Action '${AN}' already declared`> : AN;
+type AssertActionIsDefined<AN extends ActionNameType, ActionNames extends IndexType> = AN extends ActionNames ? AN : ErrorBrand<`'${AN}' is not an action`>;
 type AssertAllNonTerminalStatesHandled<Transitions, HandledStates> = 
   MapKeys<Transitions> extends HandledStates ? void : ErrorBrand<`No handlers declared for ${Exclude<MapKeys<Transitions>, HandledStates>}`>;
 
@@ -164,19 +165,20 @@ export type ActionHandlersBuilder<StateMap, Transitions, ActionsMap, HandledStat
  * The Signature of .actionHandler().
  */
 export type ActionHandlerFunc<
-  States,
+  StateMap,
   Transitions,
-  Actions,
+  ActionMap,
   HandledStates
 > = <
   S extends StateType,
   AN extends ActionNameType,
-  NS extends MapValues<States>,
+  NS extends MapValues<StateMap>,
 > (
-  state: S,
-  action: AN, // TODO: Checking that the action and state pair haven't already been declared here causes
-  handler: ActionHandlerCallback<States, Transitions, S, AN, NS, Actions>
-) => ActionHandlersBuilder<States, Transitions, Actions, HandledStates | S>;
+  // TODO: Checking that the action and state pair haven't already been declared here causes
+  state: AssertStateInMap<StateMap, S>,
+  action: AssertActionIsDefined<AN, MapKeys<ActionMap>>,
+  handler: ActionHandlerCallback<StateMap, Transitions, S, AN, NS, ActionMap>
+) => ActionHandlersBuilder<StateMap, Transitions, ActionMap, HandledStates | S>;
 
 type ActionHandlerCallback<
   States,
@@ -269,17 +271,19 @@ const action = <StateMap, Transitions, ActionMap>(): ActionFunc<StateMap, Transi
 
 const actionHandler = <StateMap, Transitions, ActionMap, HandledStates>(definition: StateMachineDefinition<StateMap, ActionMap>): ActionHandlerFunc<StateMap, Transitions, ActionMap, HandledStates> => {
   return <S extends StateType, AN extends ActionNameType, NS extends MapValues<StateMap>>(
-    state: S,
-    action: AN,
+    state: AssertStateInMap<StateMap, S>,
+    action: AssertActionIsDefined<AN, MapKeys<ActionMap>>,
     handler: ActionHandlerCallback<StateMap, Transitions, S, AN, NS, ActionMap>
   ) => {
+    const untypedState = state as unknown as S;
+    const untypedAction = action as unknown as AN;
     const newDefinition: StateMachineDefinition<StateMap, ActionMap> = {
       ...definition,
       handlers: {
         ...definition.handlers,
-        [state]: {
-          ...definition.handlers[state as string] ? definition.handlers[state as string] : {},
-          [action]: handler as any,
+        [untypedState]: {
+          ...definition.handlers[untypedState] ? definition.handlers[untypedState] : {},
+          [untypedAction]: handler as any,
         }
       }
     };

--- a/test/StateMachine.ts
+++ b/test/StateMachine.ts
@@ -154,8 +154,10 @@ describe('compile-time checking', () => {
     it('should fail when specifying same state twice', () => {
         stateMachine()
             .state<'b'>('b')
-            // @ts-expect-error
-            .state<'b'>('b');
+            .state<'b'>(
+                // @ts-expect-error
+                'b'
+            );
     });
 
     it('should fail when specifying same state twice, different payload', () => {
@@ -163,8 +165,10 @@ describe('compile-time checking', () => {
 
         stateMachine()
             .state<'b'>('b')
-            // @ts-expect-error
-            .state<'b', Payload>('b');
+            .state<'b', Payload>(
+                // @ts-expect-error
+                'b'
+            );
     });
     
     it('should fail when specifying the same transition twice', () => {
@@ -172,24 +176,33 @@ describe('compile-time checking', () => {
             .state<'a'>('a')
             .state<'b'>('b')
             .transition('a', 'b')
-            // @ts-expect-error
-            .transition('a', 'b');
+            .transition(
+                'a',
+                // @ts-expect-error
+                'b'
+            );
     });
 
     it('should fail when declaring transition from non-state', () => {
         stateMachine()
             .state<'a'>('a')
             .state<'b'>('b')
-            // @ts-expect-error
-            .transition('c', 'b');
+            .transition(
+                // @ts-expect-error
+                'c',
+                'b'
+            );
     });
 
     it('should fail when declaring transition to non-state', () => {
         stateMachine()
             .state<'a'>('a')
             .state<'b'>('b')
-            // @ts-expect-error
-            .transition('a', 'c')
+            .transition(
+                'a',
+                // @ts-expect-error
+                'c'
+            );
     });
 
     it('should fail when declaring same action more than once', () => {
@@ -198,8 +211,10 @@ describe('compile-time checking', () => {
             .state<'b'>('b')
             .transition('a', 'b')
             .action('a1')
-            // @ts-expect-error
-            .action('a1');
+            .action(
+                // @ts-expect-error
+                'a1'
+            );
     });
 
     it('should fail when declaring same action more than once', () => {
@@ -208,8 +223,10 @@ describe('compile-time checking', () => {
             .state<'b'>('b')
             .transition('a', 'b')
             .action('a1')
-            // @ts-expect-error
-            .action('a1');
+            .action(
+                // @ts-expect-error
+                'a1'
+            );
     });
 
     it('should fail when declaring handler to non-state', () => {
@@ -218,13 +235,16 @@ describe('compile-time checking', () => {
             .state<'b'>('b')
             .transition('a', 'b')
             .action('a1')
-            // @ts-expect-error
-            .actionHandler('c', 'a1', () => {
-                return {
-                    stateName: 'b'
-                };
-            });
-            
+            .actionHandler(
+                // @ts-expect-error
+                'c',
+                'a1',
+                () => {
+                    return {
+                        stateName: 'b' as const
+                    };
+                }
+            );
     });
 
     it('should fail when declaring handler to non-action', () => {
@@ -233,13 +253,16 @@ describe('compile-time checking', () => {
             .state<'b'>('b')
             .transition('a', 'b')
             .action('a1')
-            // @ts-expect-error
-            .actionHandler('a', 'a2', () => {
-                return {
-                    stateName: 'b'
-                };
-            });
-            
+            .actionHandler(
+                'a',
+                // @ts-expect-error
+                'a2',
+                () => {
+                    return {
+                        stateName: 'b' as const
+                    };
+                }
+            );            
     });
 
     it('should fail when declaring handler that transitions to non-state', () => {
@@ -248,14 +271,17 @@ describe('compile-time checking', () => {
             .state<'b'>('b')
             .transition('a', 'b')
             .action('a1')
-            // @ts-expect-error
-            .actionHandler('a', 'a1', () => {
-                return {
-                    stateName: 'c'
-                };
-            });
+            .actionHandler(
+                'a',
+                'a1',
+                // @ts-expect-error
+                () => {
+                    return {
+                        stateName: 'c' as const
+                    };
+                }
+            );
     });
-
 
     it('should fail when declaring handler that makes undeclared transition to legal state', () => {
         stateMachine()
@@ -264,12 +290,16 @@ describe('compile-time checking', () => {
             .state<'c'>('c')
             .transition('a', 'b')
             .action('a1')
-            // @ts-expect-error
-            .actionHandler('a', 'a1', () => {
-                return {
-                    stateName: 'c' as const
-                };
-            });
+            .actionHandler(
+                'a',
+                'a1',
+                // @ts-expect-error
+                () => {
+                    return {
+                        stateName: 'c' as const
+                    };
+                }
+            );
     });
 
     it('should succeed when declaring handler that makes declared transition to legal state', () => {
@@ -333,16 +363,20 @@ describe('compile-time checking', () => {
             .transition('a', 'b')
             .transition('a', 'a')
             .action('a1')
-            // @ts-expect-error
-            .actionHandler('a', 'a1', (_c, _a) => {
-                return Math.random () > 0.5 ? {
-                    stateName: 'b',
-                    bar: '8'
-                } : {
-                    stateName: 'a',
-                    foo: '9'
-                };
-            });
+            .actionHandler(
+                'a',
+                'a1',
+                // @ts-expect-error
+                (_c, _a) => {
+                    return Math.random () > 0.5 ? {
+                        stateName: 'b' as const,
+                        bar: '8' as const
+                    } : {
+                        stateName: 'a' as const,
+                        foo: '9' as const
+                    };
+                }
+            );
     });
 
     // TODO: Find a way to fix this without causing infinite type complaints

--- a/test/StateMachine.ts
+++ b/test/StateMachine.ts
@@ -722,5 +722,22 @@ describe('compile-time checking', () => {
                 return NO_DOC;
             })
             .done();
-    })
+    });
+
+    it('Should not allow specifying a state that does not reflect the argument', () => {
+        stateMachine()
+            .state<'a'>(
+                // @ts-expect-error
+                `face`
+            );
+    });
+
+    it('Should not allow circumventing errors by using ErrorBrand strings', () => {
+        stateMachine()
+            .state<'a'>('a')
+            .state<'a'>(
+                // @ts-expect-error
+                `'a' has already been declared`
+            );
+    });
 })


### PR DESCRIPTION
Action handlers can currently have invalid states and actions. There are unit tests to prevent this but unfortunately the `@ts-expect-error` was catching unrelated issues, and these parameters aren't currently checked. I've gone ahead and made the fixes required to type check the state and action here correctly.

The only user-facing change here is that I had to change `ErrorBrand`'s implementation and this will affect user-facing errors (but I hope you will agree they're more readable now).